### PR TITLE
fix: Mac needs special treatment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,7 @@ jobs:
           command: sbcl --version
   mac:
     runs-on: macos-latest
-    env:
-      CPATH: /usr/local/include:$CPATH
-      LIBRARY_PATH: /usr/local/lib:$LIBRARY_PATH
     steps:
-      - name: install dependencies
-        run: brew install zstd
       - name: asdf plugin test
         uses: asdf-vm/actions/plugin-test@v1
         with:

--- a/bin/functions
+++ b/bin/functions
@@ -8,14 +8,14 @@ SCRIPT_PATH="$(
 
 mkdir -p ${CACHE_DIR}
 
-function get_arch () {
+function get_arch() {
     local arch=""
     local arch_check="$(uname -m)"
     case "${arch_check}" in
-        x86_64|amd64) arch="x86-64"; ;;
-        i686|i386|386) arch="x86"; ;;
-        aarch64|arm64) arch="arm64"; ;;
-        ppc64le) arch="powerpc"; ;;
+    x86_64 | amd64) arch="x86-64" ;;
+    i686 | i386 | 386) arch="x86" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    ppc64le) arch="powerpc" ;;
     esac
 
     printf "%s" "$arch"
@@ -26,11 +26,20 @@ ARCH="$(get_arch)"
 
 case $(uname -s) in
 Darwin)
-    STAT="stat -f %c ${CACHE_DIR}/*"
-    TEMP_DIR=$(mktemp -dt asdf-sbcl)
-    VERSION="2.1.2"
+    case $(get_arch) in
+    arm64)
+        STAT="stat -f %c ${CACHE_DIR}/*"
+        TEMP_DIR=$(mktemp -dt asdf-sbcl)
+        VERSION="2.1.2"
+        ;;
+    x86-64)
+        STAT="stat -f %c ${CACHE_DIR}/*"
+        TEMP_DIR=$(mktemp -dt asdf-sbcl)
+        VERSION="1.2.11"
+        ;;
+    esac
     ;;
-Linux)
+*)
     STAT="stat -c %Z ${CACHE_DIR}/*"
     TEMP_DIR=$(mktemp -dp /tmp asdf-sbcl.XXXXXXXX)
     VERSION="1.4.2"


### PR DESCRIPTION
SBCL needs SBCL to bootstrap.  1.4.2 is the typical bootstrap version;
however, it is not compatible with newer Mac OS builds and
architectures.  This update allows asdf to bootstrap using the best
published version for the architecture specified.